### PR TITLE
Apply proper unsafe names

### DIFF
--- a/devotee/Cargo.toml
+++ b/devotee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devotee"
-version = "0.1.43"
+version = "0.1.45"
 edition = "2021"
 publish = true
 authors = ["PSUAN collective", "Hara Red <rtc6fg4.fejg2@gmail.com>"]

--- a/devotee/examples/invert/main.rs
+++ b/devotee/examples/invert/main.rs
@@ -93,8 +93,9 @@ impl Root<Config> for Invert {
         drop(painter);
         for x in 8..(render.width() - 8) {
             for y in 8..(render.height() - 8) {
+                // SAFETY: we are iterating in safe range.
                 unsafe {
-                    *Image::pixel_mut_unsafe(render, (x, y).into()) =
+                    *Image::unsafe_pixel_mut(render, (x, y).into()) =
                         Color([2 * x as u8, 2 * y as u8, 0x00]);
                 }
             }

--- a/devotee/src/app.rs
+++ b/devotee/src/app.rs
@@ -31,7 +31,7 @@ pub mod sound_system;
 pub mod window;
 
 /// Node constructor.
-/// Takes mutable reference to `Context` and provides constructed node.
+/// Takes mutable reference to `Context` and provides constructed root node.
 pub type Constructor<T, U> = Box<dyn FnOnce(&mut Context<U>) -> T>;
 
 /// App is the root of the `devotee` project.

--- a/devotee/src/visual.rs
+++ b/devotee/src/visual.rs
@@ -141,19 +141,19 @@ pub trait Image {
     where
         Self: 'a;
     /// Get specific pixel reference.
-    fn pixel<'a>(&'a self, position: Vector<i32>) -> Option<Self::PixelRef<'a>>;
+    fn pixel(&self, position: Vector<i32>) -> Option<Self::PixelRef<'_>>;
     /// Get specific pixel mutable reference.
-    fn pixel_mut<'a>(&'a mut self, position: Vector<i32>) -> Option<Self::PixelMut<'a>>;
+    fn pixel_mut(&mut self, position: Vector<i32>) -> Option<Self::PixelMut<'_>>;
     /// Get specific pixel reference without bounds check.
     ///
     /// # Safety
     /// - position must be in range [(0, 0), [width - 1, height - 1]]
-    unsafe fn pixel_unsafe<'a>(&'a self, position: Vector<i32>) -> Self::PixelRef<'a>;
+    unsafe fn pixel_unsafe(&self, position: Vector<i32>) -> Self::PixelRef<'_>;
     /// Get specific pixel mutable reference without bounds check.
     ///
     /// # Safety
     /// - position must be in range [(0, 0), [width - 1, height - 1]]
-    unsafe fn pixel_mut_unsafe<'a>(&'a mut self, position: Vector<i32>) -> Self::PixelMut<'a>;
+    unsafe fn pixel_mut_unsafe(&mut self, position: Vector<i32>) -> Self::PixelMut<'_>;
     /// Get width of this image.
     fn width(&self) -> i32;
     /// Get height of this image.

--- a/devotee/src/visual.rs
+++ b/devotee/src/visual.rs
@@ -148,12 +148,12 @@ pub trait Image {
     ///
     /// # Safety
     /// - position must be in range [(0, 0), [width - 1, height - 1]]
-    unsafe fn pixel_unsafe(&self, position: Vector<i32>) -> Self::PixelRef<'_>;
+    unsafe fn unsafe_pixel(&self, position: Vector<i32>) -> Self::PixelRef<'_>;
     /// Get specific pixel mutable reference without bounds check.
     ///
     /// # Safety
     /// - position must be in range [(0, 0), [width - 1, height - 1]]
-    unsafe fn pixel_mut_unsafe(&mut self, position: Vector<i32>) -> Self::PixelMut<'_>;
+    unsafe fn unsafe_pixel_mut(&mut self, position: Vector<i32>) -> Self::PixelMut<'_>;
     /// Get width of this image.
     fn width(&self) -> i32;
     /// Get height of this image.
@@ -362,8 +362,8 @@ where
             for y in start_y..end_y {
                 let step = (x, y).into();
                 unsafe {
-                    let pixel = function(x, y, self.target.pixel_unsafe(step).clone());
-                    *self.target.pixel_mut_unsafe(step) = pixel;
+                    let pixel = function(x, y, self.target.unsafe_pixel(step).clone());
+                    *self.target.unsafe_pixel_mut(step) = pixel;
                 }
             }
         }
@@ -608,16 +608,16 @@ where
                 let step = (x, y).into();
                 let pose = at + step;
                 unsafe {
-                    let color = Image::pixel_unsafe(image, step);
+                    let color = Image::unsafe_pixel(image, step);
                     let pixel = function(
                         pose.x(),
                         pose.y(),
-                        self.target.pixel_unsafe(pose).clone(),
+                        self.target.unsafe_pixel(pose).clone(),
                         x,
                         y,
                         color.clone(),
                     );
-                    *self.target.pixel_mut_unsafe(pose) = pixel;
+                    *self.target.unsafe_pixel_mut(pose) = pixel;
                 }
             }
         }
@@ -803,7 +803,7 @@ where
     where
         I: Into<Vector<i32>>,
     {
-        Image::pixel_unsafe(self.target, position.into() + self.offset)
+        Image::unsafe_pixel(self.target, position.into() + self.offset)
     }
 
     /// Get mutable reference to pixel.
@@ -814,7 +814,7 @@ where
     where
         I: Into<Vector<i32>>,
     {
-        Image::pixel_mut_unsafe(self.target, position.into() + self.offset)
+        Image::unsafe_pixel_mut(self.target, position.into() + self.offset)
     }
 
     /// Use provided function and given image on this drawable.

--- a/devotee/src/visual/canvas.rs
+++ b/devotee/src/visual/canvas.rs
@@ -63,7 +63,7 @@ where
     /// Get reference to pixel.
     /// # Safety
     /// - `position` must be in range `[0, width-1]` by `x` and `[0, height-1]` by `y`.
-    unsafe fn pixel_unsafe(&self, position: Vector<i32>) -> &P {
+    unsafe fn unsafe_pixel(&self, position: Vector<i32>) -> &P {
         let (x, y) = (position.x() as usize, position.y() as usize);
         &self.data[x + self.width * y]
     }
@@ -71,7 +71,7 @@ where
     /// Get mutable reference to pixel.
     /// # Safety
     /// - `position` must be in range `[0, width-1]` by `x` and `[0, height-1]` by `y`.
-    unsafe fn pixel_mut_unsafe(&mut self, position: Vector<i32>) -> &mut P {
+    unsafe fn unsafe_pixel_mut(&mut self, position: Vector<i32>) -> &mut P {
         let (x, y) = (position.x() as usize, position.y() as usize);
         &mut self.data[x + self.width * y]
     }
@@ -104,7 +104,7 @@ where
     type Iterator = Iter<'a, P>;
 
     unsafe fn pixel_unsafe(&self, x: u32, y: u32) -> &P {
-        Image::pixel_unsafe(self, Vector::new(x as i32, y as i32))
+        Image::unsafe_pixel(self, Vector::new(x as i32, y as i32))
     }
 
     fn width(&self) -> u32 {

--- a/devotee/src/visual/sprite.rs
+++ b/devotee/src/visual/sprite.rs
@@ -56,12 +56,12 @@ where
         }
     }
 
-    unsafe fn pixel_unsafe(&self, position: Vector<i32>) -> &P {
+    unsafe fn unsafe_pixel(&self, position: Vector<i32>) -> &P {
         let (x, y) = (position.x() as usize, position.y() as usize);
         &self.data[y][x]
     }
 
-    unsafe fn pixel_mut_unsafe(&mut self, position: Vector<i32>) -> &mut P {
+    unsafe fn unsafe_pixel_mut(&mut self, position: Vector<i32>) -> &mut P {
         let (x, y) = (position.x() as usize, position.y() as usize);
         &mut self.data[y][x]
     }
@@ -129,7 +129,7 @@ where
     type Iterator = SpriteIter<'a, P, W, H>;
 
     unsafe fn pixel_unsafe(&self, x: u32, y: u32) -> &P {
-        Image::pixel_unsafe(self, Vector::new(x as i32, y as i32))
+        Image::unsafe_pixel(self, Vector::new(x as i32, y as i32))
     }
 
     fn width(&self) -> u32 {


### PR DESCRIPTION
Renamed `Image` unsafe methods, also applied Clippy suggestions.